### PR TITLE
Mark dynamic API routes as dynamic

### DIFF
--- a/frontend/src/app/api/auth/zoom/route.ts
+++ b/frontend/src/app/api/auth/zoom/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 
+export const dynamic = 'force-dynamic';
+
 const ZOOM_AUTH_URL = 'https://zoom.us/oauth/authorize';
 const ZOOM_CLIENT_ID = process.env.ZOOM_CLIENT_ID!;
 const ZOOM_REDIRECT_URI = process.env.ZOOM_REDIRECT_URI || 'http://localhost:3000/api/auth/zoom/callback';

--- a/frontend/src/app/api/health/database/route.ts
+++ b/frontend/src/app/api/health/database/route.ts
@@ -2,6 +2,8 @@ import { createClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 import { createSuccessResponse, createErrorResponse } from '@/types/api'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(request: NextRequest) {
   try {
     const supabase = createClient()

--- a/frontend/src/app/api/recruiters/insights/route.ts
+++ b/frontend/src/app/api/recruiters/insights/route.ts
@@ -3,6 +3,8 @@ import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 
+export const dynamic = 'force-dynamic';
+
 const genAI = new GoogleGenerativeAI(process.env.GOOGLE_AI_API_KEY!);
 
 export async function GET(request: NextRequest) {

--- a/frontend/src/app/api/twilio/analytics/route.ts
+++ b/frontend/src/app/api/twilio/analytics/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createTwilioService } from '@/lib/services/twilio'
 import { createClient } from '@supabase/supabase-js'
 
+export const dynamic = 'force-dynamic'
+
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.SUPABASE_SERVICE_ROLE_KEY!

--- a/frontend/src/app/api/verify-session/route.ts
+++ b/frontend/src/app/api/verify-session/route.ts
@@ -3,6 +3,8 @@ import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { createSuccessResponse, createErrorResponse } from '@/types/api'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(request: NextRequest) {
   try {
     const cookieStore = cookies()

--- a/frontend/src/app/api/zoom/user/route.ts
+++ b/frontend/src/app/api/zoom/user/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(request: NextRequest) {
   try {
     // Get authorization header


### PR DESCRIPTION
## Summary
- mark API route handlers that read cookies or headers as dynamic

## Testing
- `npm --workspace frontend run lint` *(fails: next not found or lint errors)*
- `npm --workspace frontend test` *(fails: 19 failed, 2 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6879bf620acc8330881689bdb3c271c8