### PR TITLE
Remove deprecated Supabase auth helpers

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,7 +54,6 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/react-toast": "^1.2.14",
     "@radix-ui/react-tooltip": "^1.2.7",
-    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/realtime-js": "^2.10.1",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.43.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,6 @@
         "@radix-ui/react-tabs": "^1.1.12",
         "@radix-ui/react-toast": "^1.2.14",
         "@radix-ui/react-tooltip": "^1.2.7",
-        "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/realtime-js": "^2.10.1",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.43.4",
@@ -4351,42 +4350,6 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
-    },
-    "node_modules/@supabase/auth-helpers-nextjs": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
-      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-helpers-shared": "0.7.0",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
-    },
-    "node_modules/@supabase/auth-helpers-shared": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
-      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.14.4"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.39.8"
-      }
-    },
-    "node_modules/@supabase/auth-helpers-shared/node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.70.0",
@@ -15569,12 +15532,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",


### PR DESCRIPTION
## Summary
- remove `@supabase/auth-helpers-nextjs` from frontend dependencies
- run `npm install` to update lockfile

## Testing
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_6879bfe880b48330922deddfad2b8cef