### PR TITLE
Fix Microsoft OAuth state handling

### DIFF
--- a/frontend/src/lib/auth/microsoft-oauth.ts
+++ b/frontend/src/lib/auth/microsoft-oauth.ts
@@ -4,26 +4,38 @@
 function base64URLEncode(str: ArrayBuffer) {
   // Use a more reliable method that won't cause stack overflow
   const bytes = new Uint8Array(str);
-  let binary = '';
+  let binary = "";
   for (let i = 0; i < bytes.byteLength; i++) {
     binary += String.fromCharCode(bytes[i]);
   }
-  return btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '');
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
 }
 
 function sha256(plain: string) {
   const encoder = new TextEncoder();
   const data = encoder.encode(plain);
-  return window.crypto.subtle.digest('SHA-256', data);
+  return window.crypto.subtle.digest("SHA-256", data);
 }
 
 function generateCodeVerifier() {
   const array = new Uint8Array(32);
   window.crypto.getRandomValues(array);
   return base64URLEncode(array.buffer);
+}
+
+function setCookie(name: string, value: string, maxAgeSeconds = 300) {
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; max-age=${maxAgeSeconds}; SameSite=Lax`;
+}
+
+function getCookie(name: string): string | null {
+  const match = document.cookie.match(
+    new RegExp(
+      "(?:^|; )" +
+        name.replace(/([.$?*|{}()\[\]\\\/\+^])/g, "\\$1") +
+        "=([^;]*)",
+    ),
+  );
+  return match ? decodeURIComponent(match[1]) : null;
 }
 
 async function generateCodeChallenge(codeVerifier: string) {
@@ -33,96 +45,121 @@ async function generateCodeChallenge(codeVerifier: string) {
 
 export async function signInWithMicrosoftPKCE() {
   // Check if we're in a browser environment
-  if (typeof window === 'undefined') {
-    throw new Error('Microsoft OAuth can only be used in the browser');
+  if (typeof window === "undefined") {
+    throw new Error("Microsoft OAuth can only be used in the browser");
   }
-  
+
   // Check if crypto.subtle is available
   if (!window.crypto || !window.crypto.subtle) {
-    throw new Error('Web Crypto API is not available in this browser');
+    throw new Error("Web Crypto API is not available in this browser");
   }
-  
+
   // Generate PKCE values
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await generateCodeChallenge(codeVerifier);
-  
+
   // Microsoft OAuth configuration - Use environment variables
-  const clientId = process.env.NEXT_PUBLIC_MICROSOFT_CLIENT_ID || process.env.NEXT_PUBLIC_ENTRA_CLIENT_ID;
-  const tenantId = process.env.NEXT_PUBLIC_MICROSOFT_TENANT_ID || process.env.NEXT_PUBLIC_ENTRA_TENANT_ID;
-  
+  const clientId =
+    process.env.NEXT_PUBLIC_MICROSOFT_CLIENT_ID ||
+    process.env.NEXT_PUBLIC_ENTRA_CLIENT_ID;
+  const tenantId =
+    process.env.NEXT_PUBLIC_MICROSOFT_TENANT_ID ||
+    process.env.NEXT_PUBLIC_ENTRA_TENANT_ID;
+
   if (!clientId || !tenantId) {
-    throw new Error('Microsoft OAuth configuration missing. Please set NEXT_PUBLIC_MICROSOFT_CLIENT_ID and NEXT_PUBLIC_MICROSOFT_TENANT_ID environment variables.');
+    throw new Error(
+      "Microsoft OAuth configuration missing. Please set NEXT_PUBLIC_MICROSOFT_CLIENT_ID and NEXT_PUBLIC_MICROSOFT_TENANT_ID environment variables.",
+    );
   }
-  
+
   const redirectUri = `${window.location.origin}/auth/microsoft/callback`;
-  const scope = 'openid email profile offline_access https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send https://graph.microsoft.com/Calendars.ReadWrite https://graph.microsoft.com/Contacts.ReadWrite https://graph.microsoft.com/Files.ReadWrite.All';
-  
+  const scope =
+    "openid email profile offline_access https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send https://graph.microsoft.com/Calendars.ReadWrite https://graph.microsoft.com/Contacts.ReadWrite https://graph.microsoft.com/Files.ReadWrite.All";
+
   // Create secure state parameter without sensitive data
   const state = {
     redirectTo: `${window.location.origin}/dashboard`,
-    provider: 'azure',
+    provider: "azure",
     timestamp: Date.now(),
-    nonce: generateCodeVerifier() // Add nonce for CSRF protection
+    nonce: generateCodeVerifier(), // Add nonce for CSRF protection
   };
-  
+
   const encodedState = btoa(JSON.stringify(state));
-  
+
   // Store in sessionStorage for client-side callback
-  sessionStorage.setItem('pkce_code_verifier', codeVerifier);
-  sessionStorage.setItem('oauth_state', encodedState);
-  
+  sessionStorage.setItem("pkce_code_verifier", codeVerifier);
+  sessionStorage.setItem("oauth_state", encodedState);
+  // Also store as fallback cookies in case sessionStorage is cleared
+  setCookie("pkce_code_verifier", codeVerifier);
+  setCookie("oauth_state", encodedState);
+
   // Construct the OAuth URL with PKCE
   const params = new URLSearchParams({
     client_id: clientId,
-    response_type: 'code',
+    response_type: "code",
     redirect_uri: redirectUri,
-    response_mode: 'query',
+    response_mode: "query",
     scope: scope,
     state: encodedState,
     code_challenge: codeChallenge,
-    code_challenge_method: 'S256',
-    prompt: 'select_account', // Allow user to select account
+    code_challenge_method: "S256",
+    prompt: "select_account", // Allow user to select account
   });
-  
+
   const authUrl = `https://login.microsoftonline.com/${tenantId}/oauth2/v2.0/authorize?${params.toString()}`;
-  
+
   // Redirect to Microsoft login
   window.location.href = authUrl;
 }
 
 // Handle the OAuth callback
 export async function handleMicrosoftCallback(code: string, state: string) {
-  const codeVerifier = sessionStorage.getItem('pkce_code_verifier');
-  const savedState = sessionStorage.getItem('oauth_state');
-  
+  let codeVerifier = sessionStorage.getItem("pkce_code_verifier");
+  let savedState = sessionStorage.getItem("oauth_state");
+
+  // Fallback to cookies if sessionStorage was cleared
   if (!codeVerifier) {
-    throw new Error('PKCE code verifier not found');
+    codeVerifier = getCookie("pkce_code_verifier");
   }
-  
+  if (!savedState) {
+    savedState = getCookie("oauth_state");
+  }
+
+  if (!codeVerifier) {
+    throw new Error("PKCE code verifier not found");
+  }
+
   if (state !== savedState) {
-    throw new Error('State mismatch - possible CSRF attack');
+    const cookieState = getCookie("oauth_state");
+    if (cookieState && state === cookieState) {
+      savedState = cookieState;
+    } else {
+      throw new Error("State mismatch - possible CSRF attack");
+    }
   }
-  
+
   // Validate state timestamp (prevent replay attacks)
   try {
     const stateData = JSON.parse(atob(state));
-    const fiveMinutesAgo = Date.now() - (5 * 60 * 1000);
+    const fiveMinutesAgo = Date.now() - 5 * 60 * 1000;
     if (stateData.timestamp < fiveMinutesAgo) {
-      throw new Error('OAuth state has expired');
+      throw new Error("OAuth state has expired");
     }
   } catch (e) {
-    throw new Error('Invalid OAuth state parameter');
+    throw new Error("Invalid OAuth state parameter");
   }
-  
+
   // Clean up session storage
-  sessionStorage.removeItem('pkce_code_verifier');
-  sessionStorage.removeItem('oauth_state');
-  
+  sessionStorage.removeItem("pkce_code_verifier");
+  sessionStorage.removeItem("oauth_state");
+  setCookie("pkce_code_verifier", "", 0);
+  setCookie("oauth_state", "", 0);
+
   // Exchange code for tokens using our secure server-side endpoint
-  const tokenResponse = await fetch('/api/auth/microsoft/token', {
-    method: 'POST',
+  const tokenResponse = await fetch("/api/auth/microsoft/token", {
+    method: "POST",
     headers: {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     },
     body: JSON.stringify({
       code,
@@ -130,12 +167,12 @@ export async function handleMicrosoftCallback(code: string, state: string) {
       redirectUri: `${window.location.origin}/auth/microsoft/callback`,
     }),
   });
-  
+
   const tokenData = await tokenResponse.json();
-  
+
   if (!tokenResponse.ok) {
-    throw new Error(tokenData.error || 'Token exchange failed');
+    throw new Error(tokenData.error || "Token exchange failed");
   }
-  
+
   return tokenData;
 }

--- a/frontend/src/test/security/oauth-security-test.ts
+++ b/frontend/src/test/security/oauth-security-test.ts
@@ -3,29 +3,29 @@
  * Tests for Microsoft OAuth implementation security
  */
 
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
 
 // Mock environment variables for testing
 const mockEnvVars = {
-  NEXT_PUBLIC_MICROSOFT_CLIENT_ID: 'test-client-id',
-  NEXT_PUBLIC_MICROSOFT_TENANT_ID: 'test-tenant-id',
-  MICROSOFT_CLIENT_SECRET: 'test-client-secret',
+  NEXT_PUBLIC_MICROSOFT_CLIENT_ID: "test-client-id",
+  NEXT_PUBLIC_MICROSOFT_TENANT_ID: "test-tenant-id",
+  MICROSOFT_CLIENT_SECRET: "test-client-secret",
 };
 
-describe('Microsoft OAuth Security Tests', () => {
+describe("Microsoft OAuth Security Tests", () => {
   let originalEnv: Record<string, string | undefined>;
 
   beforeEach(() => {
     // Save original environment
     originalEnv = { ...process.env };
-    
+
     // Set test environment variables
     Object.entries(mockEnvVars).forEach(([key, value]) => {
       process.env[key] = value;
     });
 
     // Clear localStorage/sessionStorage
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       window.sessionStorage.clear();
       window.localStorage.clear();
     }
@@ -36,12 +36,12 @@ describe('Microsoft OAuth Security Tests', () => {
     process.env = originalEnv;
   });
 
-  describe('Client-side OAuth Configuration', () => {
-    it('should not expose client secret in client-side code', () => {
+  describe("Client-side OAuth Configuration", () => {
+    it("should not expose client secret in client-side code", () => {
       // This test would fail if client secret is hardcoded in client-side files
       const clientSideFiles = [
-        '/src/lib/auth/microsoft-oauth.ts',
-        '/src/app/auth/microsoft/callback/page.tsx',
+        "/src/lib/auth/microsoft-oauth.ts",
+        "/src/app/auth/microsoft/callback/page.tsx",
       ];
 
       // In a real test environment, you would scan these files for hardcoded secrets
@@ -49,32 +49,34 @@ describe('Microsoft OAuth Security Tests', () => {
       expect(true).toBe(true);
     });
 
-    it('should use environment variables for client configuration', async () => {
+    it("should use environment variables for client configuration", async () => {
       // Mock dynamic import to test the OAuth module
-      const { signInWithMicrosoftPKCE } = await import('@/lib/auth/microsoft-oauth');
-      
+      const { signInWithMicrosoftPKCE } = await import(
+        "@/lib/auth/microsoft-oauth"
+      );
+
       // Test that function throws error when env vars are missing
       delete process.env.NEXT_PUBLIC_MICROSOFT_CLIENT_ID;
-      
+
       await expect(signInWithMicrosoftPKCE()).rejects.toThrow(
-        'Microsoft OAuth configuration missing'
+        "Microsoft OAuth configuration missing",
       );
     });
   });
 
-  describe('PKCE Implementation', () => {
-    it('should generate secure code verifier', () => {
+  describe("PKCE Implementation", () => {
+    it("should generate secure code verifier", () => {
       // Test that code verifier is properly generated
-      const codeVerifier = 'test-code-verifier';
-      
+      const codeVerifier = "test-code-verifier";
+
       // Mock sessionStorage
       const mockSessionStorage = {
         getItem: jest.fn().mockReturnValue(codeVerifier),
         setItem: jest.fn(),
         removeItem: jest.fn(),
       };
-      
-      Object.defineProperty(window, 'sessionStorage', {
+
+      Object.defineProperty(window, "sessionStorage", {
         value: mockSessionStorage,
         writable: true,
       });
@@ -82,84 +84,118 @@ describe('Microsoft OAuth Security Tests', () => {
       expect(mockSessionStorage.getItem).toBeDefined();
     });
 
-    it('should validate state parameter for CSRF protection', async () => {
-      const { handleMicrosoftCallback } = await import('@/lib/auth/microsoft-oauth');
-      
+    it("should validate state parameter for CSRF protection", async () => {
+      const { handleMicrosoftCallback } = await import(
+        "@/lib/auth/microsoft-oauth"
+      );
+
       // Mock sessionStorage with invalid state
       const mockSessionStorage = {
         getItem: jest.fn().mockImplementation((key) => {
-          if (key === 'pkce_code_verifier') return 'test-verifier';
-          if (key === 'oauth_state') return 'valid-state';
+          if (key === "pkce_code_verifier") return "test-verifier";
+          if (key === "oauth_state") return "valid-state";
           return null;
         }),
         setItem: jest.fn(),
         removeItem: jest.fn(),
       };
-      
-      Object.defineProperty(window, 'sessionStorage', {
+
+      Object.defineProperty(window, "sessionStorage", {
         value: mockSessionStorage,
         writable: true,
       });
 
       // Test state mismatch
       await expect(
-        handleMicrosoftCallback('test-code', 'invalid-state')
-      ).rejects.toThrow('State mismatch - possible CSRF attack');
+        handleMicrosoftCallback("test-code", "invalid-state"),
+      ).rejects.toThrow("State mismatch - possible CSRF attack");
+    });
+
+    it("should accept state from cookie if sessionStorage missing", async () => {
+      const { handleMicrosoftCallback } = await import(
+        "@/lib/auth/microsoft-oauth"
+      );
+
+      const validState = "cookie-state";
+
+      const mockSessionStorage = {
+        getItem: jest.fn().mockReturnValue(null),
+        setItem: jest.fn(),
+        removeItem: jest.fn(),
+      };
+
+      Object.defineProperty(window, "sessionStorage", {
+        value: mockSessionStorage,
+        writable: true,
+      });
+
+      Object.defineProperty(document, "cookie", {
+        value: `oauth_state=${validState}; pkce_code_verifier=test-verifier`,
+        writable: true,
+      });
+
+      await expect(
+        handleMicrosoftCallback("code", validState),
+      ).resolves.not.toThrow();
     });
   });
 
-  describe('Token Exchange Security', () => {
-    it('should only exchange tokens server-side', async () => {
+  describe("Token Exchange Security", () => {
+    it("should only exchange tokens server-side", async () => {
       // Mock fetch to test server-side token exchange
       const mockFetch = jest.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
           user: {
-            id: 'test-user-id',
-            email: 'test@example.com',
-            name: 'Test User',
+            id: "test-user-id",
+            email: "test@example.com",
+            name: "Test User",
           },
         }),
       });
 
       global.fetch = mockFetch;
 
-      const { handleMicrosoftCallback } = await import('@/lib/auth/microsoft-oauth');
-      
+      const { handleMicrosoftCallback } = await import(
+        "@/lib/auth/microsoft-oauth"
+      );
+
       // Mock sessionStorage
-      const validState = btoa(JSON.stringify({
-        timestamp: Date.now(),
-        nonce: 'test-nonce',
-      }));
-      
+      const validState = btoa(
+        JSON.stringify({
+          timestamp: Date.now(),
+          nonce: "test-nonce",
+        }),
+      );
+
       const mockSessionStorage = {
         getItem: jest.fn().mockImplementation((key) => {
-          if (key === 'pkce_code_verifier') return 'test-verifier';
-          if (key === 'oauth_state') return validState;
+          if (key === "pkce_code_verifier") return "test-verifier";
+          if (key === "oauth_state") return validState;
           return null;
         }),
         setItem: jest.fn(),
         removeItem: jest.fn(),
       };
-      
-      Object.defineProperty(window, 'sessionStorage', {
+
+      Object.defineProperty(window, "sessionStorage", {
         value: mockSessionStorage,
         writable: true,
       });
 
       try {
-        await handleMicrosoftCallback('test-code', validState);
-        
+        await handleMicrosoftCallback("test-code", validState);
+
         // Verify server-side endpoint was called
-        expect(mockFetch).toHaveBeenCalledWith('/api/auth/microsoft/token', {
-          method: 'POST',
+        expect(mockFetch).toHaveBeenCalledWith("/api/auth/microsoft/token", {
+          method: "POST",
           headers: {
-            'Content-Type': 'application/json',
+            "Content-Type": "application/json",
           },
           body: JSON.stringify({
-            code: 'test-code',
-            codeVerifier: 'test-verifier',
-            redirectUri: 'http://localhost/auth/microsoft/callback',
+            code: "test-code",
+            codeVerifier: "test-verifier",
+            redirectUri: "http://localhost/auth/microsoft/callback",
           }),
         });
       } catch (error) {
@@ -169,34 +205,38 @@ describe('Microsoft OAuth Security Tests', () => {
     });
   });
 
-  describe('State Parameter Validation', () => {
-    it('should reject expired state parameters', async () => {
-      const { handleMicrosoftCallback } = await import('@/lib/auth/microsoft-oauth');
-      
+  describe("State Parameter Validation", () => {
+    it("should reject expired state parameters", async () => {
+      const { handleMicrosoftCallback } = await import(
+        "@/lib/auth/microsoft-oauth"
+      );
+
       // Create expired state (older than 5 minutes)
-      const expiredState = btoa(JSON.stringify({
-        timestamp: Date.now() - (10 * 60 * 1000), // 10 minutes ago
-        nonce: 'test-nonce',
-      }));
-      
+      const expiredState = btoa(
+        JSON.stringify({
+          timestamp: Date.now() - 10 * 60 * 1000, // 10 minutes ago
+          nonce: "test-nonce",
+        }),
+      );
+
       const mockSessionStorage = {
         getItem: jest.fn().mockImplementation((key) => {
-          if (key === 'pkce_code_verifier') return 'test-verifier';
-          if (key === 'oauth_state') return expiredState;
+          if (key === "pkce_code_verifier") return "test-verifier";
+          if (key === "oauth_state") return expiredState;
           return null;
         }),
         setItem: jest.fn(),
         removeItem: jest.fn(),
       };
-      
-      Object.defineProperty(window, 'sessionStorage', {
+
+      Object.defineProperty(window, "sessionStorage", {
         value: mockSessionStorage,
         writable: true,
       });
 
       await expect(
-        handleMicrosoftCallback('test-code', expiredState)
-      ).rejects.toThrow('OAuth state has expired');
+        handleMicrosoftCallback("test-code", expiredState),
+      ).rejects.toThrow("OAuth state has expired");
     });
   });
 });
@@ -204,30 +244,30 @@ describe('Microsoft OAuth Security Tests', () => {
 /**
  * Integration Tests for OAuth Security
  */
-describe('OAuth Integration Security Tests', () => {
-  it('should validate proper scope permissions', () => {
+describe("OAuth Integration Security Tests", () => {
+  it("should validate proper scope permissions", () => {
     // Test that OAuth scopes include necessary permissions
     const expectedScopes = [
-      'openid',
-      'email',
-      'profile',
-      'offline_access',
-      'https://graph.microsoft.com/Mail.ReadWrite',
-      'https://graph.microsoft.com/Mail.Send',
-      'https://graph.microsoft.com/Calendars.ReadWrite',
-      'https://graph.microsoft.com/Contacts.ReadWrite',
-      'https://graph.microsoft.com/Files.ReadWrite.All',
+      "openid",
+      "email",
+      "profile",
+      "offline_access",
+      "https://graph.microsoft.com/Mail.ReadWrite",
+      "https://graph.microsoft.com/Mail.Send",
+      "https://graph.microsoft.com/Calendars.ReadWrite",
+      "https://graph.microsoft.com/Contacts.ReadWrite",
+      "https://graph.microsoft.com/Files.ReadWrite.All",
     ];
 
     // This would test the actual scope string in the OAuth implementation
     expect(expectedScopes.length).toBeGreaterThan(0);
   });
 
-  it('should handle token refresh securely', async () => {
+  it("should handle token refresh securely", async () => {
     // Test token refresh mechanism
     const mockTokenResponse = {
-      access_token: 'new-access-token',
-      refresh_token: 'new-refresh-token',
+      access_token: "new-access-token",
+      refresh_token: "new-refresh-token",
       expires_in: 3600,
     };
 


### PR DESCRIPTION
## Summary
- add cookie helpers to Microsoft OAuth flow
- fall back to cookies for state and PKCE verifier
- clear cookies on callback success
- update OAuth callback page to use cookie fallback
- add test for cookie fallback in OAuth security test

## Testing
- `npm install` *(fails: some tests fail)*
- `npx jest --testPathPattern=src/test/security/oauth-security-test.ts` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687a094b4c40833082eb78e1e7fe2029