### PR TITLE
Fix Gemini API key lookup

### DIFF
--- a/frontend/src/lib/gemini/client.ts
+++ b/frontend/src/lib/gemini/client.ts
@@ -1,7 +1,15 @@
 import { GoogleGenerativeAI } from '@google/generative-ai'
 
-// Initialize Gemini clients
-const genAI = new GoogleGenerativeAI(process.env.NEXT_PUBLIC_GEMINI_API_KEY!)
+// Initialize Gemini client with available API key
+const geminiApiKey =
+  process.env.NEXT_PUBLIC_GEMINI_API_KEY ||
+  process.env.GOOGLE_GENERATIVE_AI_API_KEY
+
+if (!geminiApiKey) {
+  throw new Error('GEMINI API key is not configured')
+}
+
+const genAI = new GoogleGenerativeAI(geminiApiKey)
 
 // Model configurations
 export const models = {


### PR DESCRIPTION
## Summary
- fall back to `GOOGLE_GENERATIVE_AI_API_KEY` when `NEXT_PUBLIC_GEMINI_API_KEY` is missing

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities, exhaustive-deps, etc.)*
- `npm run type-check` *(fails: could not determine executable to run)*
- `npm test` *(fails: Jest test suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_687eca8a49848330bbe63fc97d9969d3